### PR TITLE
feat: 🎸 add docker-compose configuration for local PostgreSQL and Red…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  local-postgres:
+    image:  docker.io/library/postgres:14.17-bookworm
+    container_name: local-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: chatgpt
+      PGDATA: /data/postgres
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - local-postgres:/data/postgres
+    networks:
+      chatgpt-net:
+        aliases:
+          - postgres
+  local-redis:
+    image: docker.io/library/redis:7.2.4
+    container_name: local-redis
+    ports:
+      - "6379:6379"
+      - "26379:26379"
+    networks:
+      chatgpt-net:
+        aliases:
+          - redis
+networks:
+  chatgpt-net:
+    name: chatgpt-net
+    ipam:
+      config:
+        - subnet: 172.22.0.0/16
+          gateway: 172.22.0.1
+
+volumes:
+  local-postgres:
+


### PR DESCRIPTION
This pull request introduces a `docker-compose.yml` file to streamline the setup of local development environments by defining services for PostgreSQL and Redis. The most important changes include configuring these services, defining a custom network, and setting up persistent storage for PostgreSQL.

### Added services for local development:
* Added a `local-postgres` service using the `postgres:14.17-bookworm` image. It includes environment variables for the database configuration, persistent storage via a Docker volume, and exposes port `5432` for external access.
* Added a `local-redis` service using the `redis:7.2.4` image. It exposes ports `6379` and `26379` for external access.

### Network configuration:
* Created a custom Docker network `chatgpt-net` with a specified subnet (`172.22.0.0/16`) and gateway (`172.22.0.1`) for inter-service communication.

### Persistent storage:
* Configured a Docker volume `local-postgres` for the PostgreSQL service to ensure data persistence.…is services